### PR TITLE
Prepared for install via npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ npm-debug.log
 
 # Ignore VSCode Config
 .vscode
+
+#Ignoderd files
+*.js
+*.map
+*.d.ts

--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,7 @@ karma.conf.js
 .travis.yml
 .gitignore
 tsconfig.json
+
+# Ignored Files
+*.ts
+!*.d.ts

--- a/angular2-token.d.ts
+++ b/angular2-token.d.ts
@@ -1,3 +1,3 @@
-export * from './src/angular2-token.model';
-export * from './src/angular2-token.service';
-export * from './src/a2t-ui/a2t-ui.module';
+export * from './lib/angular2-token.model';
+export * from './lib/angular2-token.service';
+export * from './lib/a2t-ui/a2t-ui.module';

--- a/package.json
+++ b/package.json
@@ -23,22 +23,16 @@
     "rxjs": "5.0.0-beta.12"
   },
   "devDependencies": {
-
-    "@angular/core": "^2.0.0",
-    "@angular/http": "^2.0.0",
     "@angular/common": "^2.0.0",
-    "@angular/router": "^3.0.0",
-    "@angular/forms": "^2.0.0",
-    "rxjs": "5.0.0-beta.12",
-
     "@angular/compiler": "^2.0.0",
+    "@angular/core": "^2.0.0",
+    "@angular/forms": "^2.0.0",
+    "@angular/http": "^2.0.0",
     "@angular/platform-browser": "^2.0.0",
     "@angular/platform-browser-dynamic": "^2.0.0",
     "@angular/platform-server": "^2.0.0",
-    "ie-shim": "^0.1.0",
-    "typescript": "^2.0.3",
-    "zone.js": "0.6.23",
-
+    "@angular/router": "^3.0.0",
+    "@types/core-js": "^0.9.34",
     "@types/hammerjs": "^2.0.33",
     "@types/jasmine": "^2.2.34",
     "@types/node": "^6.0.38",
@@ -46,17 +40,11 @@
     "@types/selenium-webdriver": "2.44.29",
     "@types/source-map": "^0.1.27",
     "@types/webpack": "^1.12.34",
-    "@types/core-js": "^0.9.34",
-
     "awesome-typescript-loader": "^2.2.1",
-    "source-map-loader": "^0.1.5",
-    "istanbul-instrumenter-loader": "^1.0.0",
-
-    "protractor": "4.0.10",
-
     "core-js": "^2.4.1",
     "http-server": "^0.9.0",
-
+    "ie-shim": "^0.1.0",
+    "istanbul-instrumenter-loader": "^1.0.0",
     "jasmine-core": "^2.4.1",
     "karma": "1.3.0",
     "karma-chrome-launcher": "^2.0.0",
@@ -65,18 +53,21 @@
     "karma-mocha-reporter": "^2.0.0",
     "karma-sourcemap-loader": "^0.3.7",
     "karma-webpack": "1.8.0",
+    "protractor": "4.0.10",
     "remap-istanbul": "^0.7.0",
-
+    "rxjs": "5.0.0-beta.12",
+    "source-map-loader": "^0.1.5",
     "ts-helpers": "1.1.2",
     "ts-node": "1.6.1",
-    "webpack": "^1.13.2"
+    "typescript": "^2.0.3",
+    "webpack": "^1.13.2",
+    "zone.js": "0.6.23"
   },
   "author": "Jan-Philipp Riethmacher <neroniaky@gmail.com>",
   "license": "MIT",
-  "repository" :
-  {
-    "type" : "git",
-    "url" : "git+https://github.com/neroniaky/angular2-token.git"
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/neroniaky/angular2-token.git"
   },
   "bugs": {
     "url": "https://github.com/neroniaky/angular2-token/issues"

--- a/src/a2t-ui/a2t-ui.routes.ts
+++ b/src/a2t-ui/a2t-ui.routes.ts
@@ -1,3 +1,4 @@
+import { ModuleWithProviders } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 import { Angular2TokenService } from '../angular2-token.service';
 
@@ -14,10 +15,10 @@ const routes: Routes = [{
             { path: 'sign-in', component: A2tSignInComponent },
             { path: 'sign-up', component: A2tSignUpComponent },
             { path: 'reset-password', component: A2tResetPasswordComponent },
-            { 
-                path: 'update-password', 
-                component: A2tUpdatePasswordComponent, 
-                canActivate: [Angular2TokenService] 
+            {
+                path: 'update-password',
+                component: A2tUpdatePasswordComponent,
+                canActivate: [Angular2TokenService]
             }
         ]
 }];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,16 +6,17 @@
         "emitDecoratorMetadata": true,
         "experimentalDecorators": true,
         "sourceMap": true,
-        //"declaration": true,
+        "declaration": true,
         "outDir": "lib",
         "suppressImplicitAnyIndexErrors": true
     },
-    "files": [
-        "src/angular2-token.service.ts",
-        "src/a2t-ui/a2t-ui.module.ts"
+    "dirs": [
+        "src"
     ],
     "exclude": [
-        "node_modules"
+        "node_modules",
+        "**/*.spec.ts",
+        "angular2-token.d.ts"
     ],
     "types": [
         "core-js",


### PR DESCRIPTION
This changes resolve #69 when `git clone`ing and running `npm install` local.
In package.json this means:
`"angular2-token": "file:/local_modules/angular2-token"` when /local_modules/angular2-token is the directory, where the repository is cloned into.

It does not work when installing directly from git (see [npm issues](https://github.com/npm/npm/issues/3055)) For installing via npm registry this should work, as preinstall script from package.json is used both ways - installing from local and installing from npm registry.