### PR TITLE
added cleanup()

### DIFF
--- a/src/angular2-token.service.ts
+++ b/src/angular2-token.service.ts
@@ -190,10 +190,7 @@ export class Angular2TokenService implements CanActivate {
         this._getAuthDataFromParams();
     }
 
-    // Sign out request and delete storage
-    signOut(): Observable<Response> {
-        let observ = this.delete(this._constructUserPath() + this._options.signOutPath);
-
+    cleanup() {
         localStorage.removeItem('accessToken');
         localStorage.removeItem('client');
         localStorage.removeItem('expiry');
@@ -203,6 +200,13 @@ export class Angular2TokenService implements CanActivate {
         this._currentAuthData = null;
         this._currentUserType = null;
         this._currentUserData = null;
+    }
+
+    // Sign out request and delete storage
+    signOut(): Observable<Response> {
+        let observ = this.delete(this._constructUserPath() + this._options.signOutPath);
+
+        this.cleanup();
 
         return observ;
     }


### PR DESCRIPTION
sometimes you want to be sure then ui part is clean, and somehow localStorage.removeItem on signOut didn't work correctly so I had to run cleanup() method.