### PR TITLE
ng-auth-token compatibility

### DIFF
--- a/src/angular2-token.model.ts
+++ b/src/angular2-token.model.ts
@@ -83,4 +83,5 @@ export interface Angular2TokenOptions {
     oAuthWindowType?:           string;
 
     globalOptions?:             GlobalOptions;
+    storageKey?:                string;
 }

--- a/src/angular2-token.service.ts
+++ b/src/angular2-token.service.ts
@@ -190,10 +190,7 @@ export class Angular2TokenService implements CanActivate {
         this._getAuthDataFromParams();
     }
 
-    // Sign out request and delete storage
-    signOut(): Observable<Response> {
-        let observ = this.delete(this._constructUserPath() + this._options.signOutPath);
-
+    cleanup() {
         localStorage.removeItem('accessToken');
         localStorage.removeItem('client');
         localStorage.removeItem('expiry');
@@ -203,6 +200,13 @@ export class Angular2TokenService implements CanActivate {
         this._currentAuthData = null;
         this._currentUserType = null;
         this._currentUserData = null;
+    }
+
+    // Sign out request and delete storage
+    signOut(): Observable<Response> {
+        let observ = this.delete(this._constructUserPath() + this._options.signOutPath);
+
+        this.cleanup();
 
         return observ;
     }

--- a/src/angular2-token.service.ts
+++ b/src/angular2-token.service.ts
@@ -118,7 +118,8 @@ export class Angular2TokenService implements CanActivate {
                     'Content-Type': 'application/json',
                     'Accept':       'application/json'
                 }
-            }
+            },
+            storageKey: null
         };
 
         this._options = (<any>Object).assign(defaultOptions, options);
@@ -191,11 +192,15 @@ export class Angular2TokenService implements CanActivate {
     }
 
     cleanup() {
-        localStorage.removeItem('accessToken');
-        localStorage.removeItem('client');
-        localStorage.removeItem('expiry');
-        localStorage.removeItem('tokenType');
-        localStorage.removeItem('uid');
+        if (this._options.storageKey) {
+          localStorage.removeItem(this._options.storageKey);
+        } else {
+          localStorage.removeItem('accessToken');
+          localStorage.removeItem('client');
+          localStorage.removeItem('expiry');
+          localStorage.removeItem('tokenType');
+          localStorage.removeItem('uid');
+        }
 
         this._currentAuthData = null;
         this._currentUserType = null;
@@ -385,14 +390,21 @@ export class Angular2TokenService implements CanActivate {
 
     // Try to get auth data from storage.
     private _getAuthDataFromStorage() {
+        let authData: AuthData;
 
-        let authData: AuthData = {
+        if (this._options.storageKey) {
+           authData = JSON.parse(
+             localStorage.getItem(this._options.storageKey) || '{}'
+           );
+        } else {
+           authData = {
             accessToken:    localStorage.getItem('accessToken'),
             client:         localStorage.getItem('client'),
             expiry:         localStorage.getItem('expiry'),
             tokenType:      localStorage.getItem('tokenType'),
             uid:            localStorage.getItem('uid')
-        };
+          };
+        }
 
         if (this._checkIfComplete(authData))
             this._currentAuthData = authData;
@@ -434,11 +446,17 @@ export class Angular2TokenService implements CanActivate {
 
             this._currentAuthData = authData;
 
-            localStorage.setItem('accessToken', authData.accessToken);
-            localStorage.setItem('client', authData.client);
-            localStorage.setItem('expiry', authData.expiry);
-            localStorage.setItem('tokenType', authData.tokenType);
-            localStorage.setItem('uid', authData.uid);
+            if (this._options.storageKey) {
+              localStorage.setItem(
+                this._options.storageKey, JSON.stringify(authData)
+              );
+            } else {
+              localStorage.setItem('accessToken', authData.accessToken);
+              localStorage.setItem('client', authData.client);
+              localStorage.setItem('expiry', authData.expiry);
+              localStorage.setItem('tokenType', authData.tokenType);
+              localStorage.setItem('uid', authData.uid);
+            }
 
             if (this._currentUserType != null)
                 localStorage.setItem('userType', this._currentUserType.name);
@@ -449,11 +467,11 @@ export class Angular2TokenService implements CanActivate {
     // Check if auth data complete
     private _checkIfComplete(authData: AuthData): boolean {
         if (
-            authData.accessToken != null &&
-            authData.client != null &&
-            authData.expiry != null &&
-            authData.tokenType != null &&
-            authData.uid != null
+            authData.accessToken != null && authData.accessToken != undefined &&
+            authData.client != null  && authData.client != undefined &&
+            authData.expiry != null  && authData.expiry != undefined &&
+            authData.tokenType != null  && authData.tokenType != undefined &&
+            authData.uid != null  && authData.uid != undefined
         ) {
             return true;
         } else {

--- a/src/angular2-token.service.ts
+++ b/src/angular2-token.service.ts
@@ -390,21 +390,23 @@ export class Angular2TokenService implements CanActivate {
 
     // Try to get auth data from storage.
     private _getAuthDataFromStorage() {
-        let authData: AuthData;
+        let authDataFromStorage;
 
         if (this._options.storageKey) {
-           authData = JSON.parse(
-             localStorage.getItem(this._options.storageKey) || '{}'
-           );
+          authDataFromStorage = JSON.parse(
+            localStorage.getItem(this._options.storageKey) || '{}'
+          );
         } else {
-           authData = {
-            accessToken:    localStorage.getItem('accessToken'),
-            client:         localStorage.getItem('client'),
-            expiry:         localStorage.getItem('expiry'),
-            tokenType:      localStorage.getItem('tokenType'),
-            uid:            localStorage.getItem('uid')
-          };
+          authDataFromStorage = localStorage;
         }
+
+        let authData: AuthData = {
+            accessToken:    authDataFromStorage['access-token'],
+            client:         authDataFromStorage['client'],
+            expiry:         authDataFromStorage['expiry'],
+            tokenType:      authDataFromStorage['token-type'],
+            uid:            authDataFromStorage['uid']
+        };
 
         if (this._checkIfComplete(authData))
             this._currentAuthData = authData;
@@ -439,6 +441,16 @@ export class Angular2TokenService implements CanActivate {
         this._setAuthData(authData);
     }
 
+    private _dasherize(data: any) {
+      return (<any>Object).assign({}, {
+        'access-token': data.accessToken,
+        'client':       data.client,
+        'expiry':       data.expiry,
+        'token-type':   data.tokenType,
+        'uid':          data.uid
+      });
+    }
+
     // Write auth data to storage
     private _setAuthData(authData: AuthData) {
 
@@ -448,13 +460,13 @@ export class Angular2TokenService implements CanActivate {
 
             if (this._options.storageKey) {
               localStorage.setItem(
-                this._options.storageKey, JSON.stringify(authData)
+                this._options.storageKey, JSON.stringify(this._dasherize(authData))
               );
             } else {
-              localStorage.setItem('accessToken', authData.accessToken);
+              localStorage.setItem('access-token', authData.accessToken);
               localStorage.setItem('client', authData.client);
               localStorage.setItem('expiry', authData.expiry);
-              localStorage.setItem('tokenType', authData.tokenType);
+              localStorage.setItem('token-type', authData.tokenType);
               localStorage.setItem('uid', authData.uid);
             }
 

--- a/src/angular2-token.service.ts
+++ b/src/angular2-token.service.ts
@@ -48,6 +48,10 @@ export class Angular2TokenService implements CanActivate {
         return this._currentAuthData;
     }
 
+    get currentAuthDataHeaders(): Object {
+        return this._prepareData(this._currentAuthData);
+    }
+
     private _options: Angular2TokenOptions;
     private _currentUserType: UserType;
     private _currentAuthData: AuthData;
@@ -329,16 +333,10 @@ export class Angular2TokenService implements CanActivate {
 
         let baseRequestOptions: RequestOptions;
         let baseHeaders:        { [key:string]: string; } = this._options.globalOptions.headers;
-        
+
         // Merge auth headers to request if set
         if (this._currentAuthData != null) {
-            (<any>Object).assign(baseHeaders, {
-                'access-token': this._currentAuthData.accessToken,
-                'client':       this._currentAuthData.client,
-                'expiry':       this._currentAuthData.expiry,
-                'token-type':   this._currentAuthData.tokenType,
-                'uid':          this._currentAuthData.uid
-            });
+          this._prepareData(this._currentAuthData, baseHeaders);
         }
 
         baseRequestOptions = new RequestOptions({
@@ -441,8 +439,11 @@ export class Angular2TokenService implements CanActivate {
         this._setAuthData(authData);
     }
 
-    private _dasherize(data: any) {
-      return (<any>Object).assign({}, {
+    private _prepareData(data: any, mergeWith = {}) {
+      if(!data) {
+        return {};
+      }
+      return (<any>Object).assign(mergeWith, {
         'access-token': data.accessToken,
         'client':       data.client,
         'expiry':       data.expiry,
@@ -460,7 +461,7 @@ export class Angular2TokenService implements CanActivate {
 
             if (this._options.storageKey) {
               localStorage.setItem(
-                this._options.storageKey, JSON.stringify(this._dasherize(authData))
+                this._options.storageKey, JSON.stringify(this._prepareData(authData))
               );
             } else {
               localStorage.setItem('access-token', authData.accessToken);


### PR DESCRIPTION
Initial proposal. This
- exposes cleanup fn for making possible to remove/clean localStorage data
- adds possibility to store localStorage data under one key configured by storageKey
- dasherize keys for localStorage
- expose current auth data as headers

with changes above angular2-token will be compatible with https://github.com/lynndylanhurley/ng-token-auth and can be used side-by-side with it