### PR TITLE
Fix tsc noUnusedParameters validation

### DIFF
--- a/src/angular2-token.service.ts
+++ b/src/angular2-token.service.ts
@@ -164,7 +164,7 @@ export class Angular2TokenService implements CanActivate {
 
         let observ = this.post(this._constructUserPath() + this._options.signInPath, body);
 
-        observ.subscribe(res => this._currentUserData = res.json().data, error => null);
+        observ.subscribe(res => this._currentUserData = res.json().data, _error => null);
 
         return observ;
     }


### PR DESCRIPTION
So that we can use `--noUnusedParameters` as a compiler option: https://www.typescriptlang.org/docs/handbook/compiler-options.html