### PR TITLE
Implement currentAuthHeaders() to return correctly formatted headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,6 +434,11 @@ Returns current authentication data which are used to set auth headers.
 
 `get currentAuthData(): AuthData`
 
+### .currentAuthHeaders
+Returns current authentication data as an HTTP ready Header object.
+
+`get currentAuthHeaders(): Header`
+
 ### Redirect original requested URL
 If you want to redirect to the protected URL after signing in, you need to set `signInStoredUrlStorageKey` and in your code you can do something like this
 

--- a/src/angular2-token.service.ts
+++ b/src/angular2-token.service.ts
@@ -48,6 +48,20 @@ export class Angular2TokenService implements CanActivate {
         return this._currentAuthData;
     }
 
+    get currentAuthHeaders(): Headers {
+        if (this._currentAuthData != null) {
+            return new Headers({
+                'access-token': this._currentAuthData.accessToken,
+                'client':       this._currentAuthData.client,
+                'expiry':       this._currentAuthData.expiry,
+                'token-type':   this._currentAuthData.tokenType,
+                'uid':          this._currentAuthData.uid
+            });
+        }
+
+        return new Headers;
+    }
+
     private _options: Angular2TokenOptions;
     private _currentUserType: UserType;
     private _currentAuthData: AuthData;


### PR DESCRIPTION
The `currentAuthData()` method does not format the headers the way Devise Token Auth is expecting them. It is currently missing hyphens in `access-token` and `token-type`. This prevents using the returned `AuthData` object as headers in custom HTTP requests not using this library.

This PR allows the retrieval of these headers in the correct format via a Header object.