### PR TITLE
Enable the use of non-origin oAuth urls + new window options

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,14 +260,15 @@ this._tokenService.validateToken().subscribe(
 ### .updatePassword()
 Updates the password for the logged in user.
 
-`updatePassword({password: string, passwordConfirmation: string, currentPassword?: string, userType?: string}): Observable<Response>`
+`updatePassword({password: string, passwordConfirmation: string, currentPassword?: string, userType?: string, resetPasswordToken?: string}): Observable<Response>`
 
 #### Example:
 ```javascript
 this._tokenService.updatePassword({
     password:             'newPassword',
     passwordConfirmation: 'newPassword',
-    passwordCurrent:      'oldPassword'
+    passwordCurrent:      'oldPassword',
+    resetPasswordToken:   'resetPasswordToken',
 }).subscribe(
     res =>      console.log(res),
     error =>    console.log(error)

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ constructor(private _tokenService: Angular2TokenService) {
 
 | Options                                 | Description                              |
 | --------------------------------------- | ---------------------------------------- |
+| `apiBase?: string`                      | Sets the server for all API calls.       |
 | `apiPath?: string`                      | Sets base path all operations are based on |
 | `signInPath?: string`                   | Sets path for sign in                    |
 | `signInRedirect?: string`               | Sets redirect path for failed CanActivate |
@@ -167,7 +168,7 @@ constructor(private _tokenService: Angular2TokenService) {
 | `resetPasswordCallback?: string`        | Sets the path user are redirected to after email confirmation for password reset |
 | `userTypes?: UserTypes[]`               | Allows the configuration of multiple user types (see [Multiple User Types](#multiple-user-types)) |
 | `globalOptions?: GlobalOptions`         | Allows the configuration of global options (see below) |
-| `oAuthHost?: string`                    | Configure the OAuth hostname (used for backends on a different url) |
+| `oAuthBase?: string`                    | Configure the OAuth server (used for backends on a different url) |
 | `oAuthPaths?: { [key:string]: string }` | Sets paths for sign in with OAuth        |
 | `oAuthCallbackPath?:  string`           | Sets path for OAuth sameWindow callback  |
 | `oAuthWindowType?:`string`              | Window type for Oauth authentication     |

--- a/README.md
+++ b/README.md
@@ -130,11 +130,13 @@ constructor(private _tokenService: Angular2TokenService) {
         resetPasswordPath:          'auth/password',
         resetPasswordCallback:      window.location.href,
 
+        oAuthHost:                  window.location.origin,
         oAuthPaths: {
             github:                 'auth/github'
         },
         oAuthCallbackPath:          'oauth_callback',
         oAuthWindowType:            'newWindow',
+        oAuthWindowOptions:         null,
 
         userTypes:                  null,
 
@@ -165,9 +167,11 @@ constructor(private _tokenService: Angular2TokenService) {
 | `resetPasswordCallback?: string`        | Sets the path user are redirected to after email confirmation for password reset |
 | `userTypes?: UserTypes[]`               | Allows the configuration of multiple user types (see [Multiple User Types](#multiple-user-types)) |
 | `globalOptions?: GlobalOptions`         | Allows the configuration of global options (see below) |
+| `oAuthHost?: string`                    | Configure the OAuth hostname (used for backends on a different url) |
 | `oAuthPaths?: { [key:string]: string }` | Sets paths for sign in with OAuth        |
 | `oAuthCallbackPath?:  string`           | Sets path for OAuth sameWindow callback  |
 | `oAuthWindowType?:`string`              | Window type for Oauth authentication     |
+| `oAuthWindowOptions?: { [key:string]: string }` | Set additional options for the new window |
 ### Global Options
 | Options                               | Description                                     |
 | ------------------------------------- | ----------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ constructor(private _tokenService: Angular2TokenService) {
 | `oAuthPaths?: { [key:string]: string }` | Sets paths for sign in with OAuth        |
 | `oAuthCallbackPath?:  string`           | Sets path for OAuth sameWindow callback  |
 | `oAuthWindowType?:`string`              | Window type for Oauth authentication     |
-| `oAuthWindowOptions?: { [key:string]: string }` | Set additional options for the new window |
+| `oAuthWindowOptions?: { [key:string]: string }` | Set additional options to pass into `window.open()` |
 ### Global Options
 | Options                               | Description                                     |
 | ------------------------------------- | ----------------------------------------------- |

--- a/src/angular2-token.model.ts
+++ b/src/angular2-token.model.ts
@@ -82,6 +82,7 @@ export interface Angular2TokenOptions {
     oAuthPaths?:                { [key:string]: string; };
     oAuthCallbackPath?:         string;
     oAuthWindowType?:           string;
+    oAuthWindowOptions?:        string;
 
     globalOptions?:             GlobalOptions;
 }

--- a/src/angular2-token.model.ts
+++ b/src/angular2-token.model.ts
@@ -19,6 +19,7 @@ export interface UpdatePasswordData {
     passwordConfirmation:   string;
     passwordCurrent:        string;
     userType?:              string;
+    resetPasswordToken?:    string;
 }
 
 export interface ResetPasswordData {

--- a/src/angular2-token.model.ts
+++ b/src/angular2-token.model.ts
@@ -57,6 +57,7 @@ export interface GlobalOptions {
 }
 
 export interface Angular2TokenOptions {
+    apiBase?:                   string;
     apiPath?:                   string;
 
     signInPath?:                string;
@@ -78,7 +79,7 @@ export interface Angular2TokenOptions {
 
     userTypes?:                 UserType[];
 
-    oAuthHost?:                 string;
+    oAuthBase?:                 string;
     oAuthPaths?:                { [key:string]: string; };
     oAuthCallbackPath?:         string;
     oAuthWindowType?:           string;

--- a/src/angular2-token.model.ts
+++ b/src/angular2-token.model.ts
@@ -78,6 +78,7 @@ export interface Angular2TokenOptions {
 
     userTypes?:                 UserType[];
 
+    oAuthHost?:                 string;
     oAuthPaths?:                { [key:string]: string; };
     oAuthCallbackPath?:         string;
     oAuthWindowType?:           string;

--- a/src/angular2-token.model.ts
+++ b/src/angular2-token.model.ts
@@ -82,7 +82,7 @@ export interface Angular2TokenOptions {
     oAuthPaths?:                { [key:string]: string; };
     oAuthCallbackPath?:         string;
     oAuthWindowType?:           string;
-    oAuthWindowOptions?:        string;
+    oAuthWindowOptions?:        { [key:string]: string; };
 
     globalOptions?:             GlobalOptions;
 }

--- a/src/angular2-token.model.ts
+++ b/src/angular2-token.model.ts
@@ -10,6 +10,7 @@ export interface RegisterData {
     email:                  string;
     password:               string;
     passwordConfirmation:   string;
+    name?:                  string;
     userType?:              string;
 }
 

--- a/src/angular2-token.service.ts
+++ b/src/angular2-token.service.ts
@@ -128,6 +128,8 @@ export class Angular2TokenService implements CanActivate {
             },
             oAuthCallbackPath:          'oauth_callback',
             oAuthWindowType:            'newWindow',
+            oAuthWindowOptions:         '',
+
             globalOptions: {
                 headers: {
                     'Content-Type': 'application/json',
@@ -192,7 +194,11 @@ export class Angular2TokenService implements CanActivate {
         let authUrl: string = this._buildOAuthUrl(oAuthPath, callbackUrl, oAuthWindowType);
 
         if (oAuthWindowType == 'newWindow') {
-            let popup = window.open(authUrl, '_blank', 'closebuttoncaption=Cancel');
+            let popup = window.open(
+                authUrl,
+                '_blank',
+                `closebuttoncaption=Cancel,${this._options.oAuthWindowOptions}`
+            );
             return this._requestCredentialsViaPostMessage(popup);
         } else if (oAuthWindowType == 'sameWindow') {
             window.location.href = authUrl;

--- a/src/angular2-token.service.ts
+++ b/src/angular2-token.service.ts
@@ -128,7 +128,7 @@ export class Angular2TokenService implements CanActivate {
             },
             oAuthCallbackPath:          'oauth_callback',
             oAuthWindowType:            'newWindow',
-            oAuthWindowOptions:         '',
+            oAuthWindowOptions:         null,
 
             globalOptions: {
                 headers: {
@@ -194,10 +194,19 @@ export class Angular2TokenService implements CanActivate {
         let authUrl: string = this._buildOAuthUrl(oAuthPath, callbackUrl, oAuthWindowType);
 
         if (oAuthWindowType == 'newWindow') {
+            let oAuthWindowOptions = this._options.oAuthWindowOptions;
+            let windowOptions = '';
+
+            if (oAuthWindowOptions) {
+                for (let key in oAuthWindowOptions) {
+                    windowOptions += `,${key}=${oAuthWindowOptions[key]}`;
+                }
+            }
+
             let popup = window.open(
                 authUrl,
                 '_blank',
-                `closebuttoncaption=Cancel,${this._options.oAuthWindowOptions}`
+                `closebuttoncaption=Cancel${windowOptions}`
             );
             return this._requestCredentialsViaPostMessage(popup);
         } else if (oAuthWindowType == 'sameWindow') {

--- a/src/angular2-token.service.ts
+++ b/src/angular2-token.service.ts
@@ -530,7 +530,7 @@ export class Angular2TokenService implements CanActivate {
         oAuthPath = this._options.oAuthPaths[oAuthType];
 
         if (oAuthPath == null)
-            oAuthPath = '/auth/${oAuthType}';
+            oAuthPath = `/auth/${oAuthType}`;
 
         return oAuthPath;
     }
@@ -539,11 +539,11 @@ export class Angular2TokenService implements CanActivate {
         let url: string;
 
         url =   `${this._options.oAuthHost}/${oAuthPath}`;
-        url +=  '?omniauth_window_type=${windowType}';
-        url +=  '&auth_origin_url=${encodeURIComponent(callbackUrl)}';
+        url +=  `?omniauth_window_type=${windowType}`;
+        url +=  `&auth_origin_url=${encodeURIComponent(callbackUrl)}`;
 
         if (this._currentUserType != null)
-            url += '&resource_class=${this._currentUserType.name}';
+            url += `&resource_class=${this._currentUserType.name}`;
 
         return url;
     }
@@ -552,7 +552,7 @@ export class Angular2TokenService implements CanActivate {
         let pollerObserv = Observable.interval(500);
 
         let responseObserv = Observable.fromEvent(window, 'message').pluck('data')
-                                .filter(this._oAuthWindowResponseFilter);
+            .filter(this._oAuthWindowResponseFilter);
 
         let responseSubscription = responseObserv.subscribe(
             this._getAuthDataFromPostMessage.bind(this)

--- a/src/angular2-token.service.ts
+++ b/src/angular2-token.service.ts
@@ -122,6 +122,7 @@ export class Angular2TokenService implements CanActivate {
 
             userTypes:                  null,
 
+            oAuthHost:                  window.location.origin,
             oAuthPaths: {
                 github:                 'auth/github'
             },
@@ -531,7 +532,7 @@ export class Angular2TokenService implements CanActivate {
     private _buildOAuthUrl(oAuthPath: string, callbackUrl: string, windowType: string): string {
         let url: string;
 
-        url =   '${window.location.origin}/${oAuthPath}';
+        url =   `${this._options.oAuthHost}/${oAuthPath}`;
         url +=  '?omniauth_window_type=${windowType}';
         url +=  '&auth_origin_url=${encodeURIComponent(callbackUrl)}';
 

--- a/src/angular2-token.service.ts
+++ b/src/angular2-token.service.ts
@@ -102,6 +102,7 @@ export class Angular2TokenService implements CanActivate {
 
         let defaultOptions: Angular2TokenOptions = {
             apiPath:                    null,
+            apiBase:                    '',
 
             signInPath:                 'auth/sign_in',
             signInRedirect:             null,
@@ -122,7 +123,7 @@ export class Angular2TokenService implements CanActivate {
 
             userTypes:                  null,
 
-            oAuthHost:                  window.location.origin,
+            oAuthBase:                  window.location.origin,
             oAuthPaths: {
                 github:                 'auth/github'
             },
@@ -521,16 +522,16 @@ export class Angular2TokenService implements CanActivate {
 
     private _constructUserPath(): string {
         if (this._currentUserType == null)
-            return '';
+            return '/';
         else
             return this._currentUserType.path + '/';
     }
 
     private _constructApiPath(): string {
         if (this._options.apiPath == null)
-            return '';
+            return this._options.apiBase + '/';
         else
-            return this._options.apiPath + '/';
+            return this._options.apiBase + '/' + this._options.apiPath + '/';
     }
 
     private _getOAuthPath(oAuthType: string): string {
@@ -547,7 +548,7 @@ export class Angular2TokenService implements CanActivate {
     private _buildOAuthUrl(oAuthPath: string, callbackUrl: string, windowType: string): string {
         let url: string;
 
-        url =   `${this._options.oAuthHost}/${oAuthPath}`;
+        url =   `${this._options.oAuthBase}/${oAuthPath}`;
         url +=  `?omniauth_window_type=${windowType}`;
         url +=  `&auth_origin_url=${encodeURIComponent(callbackUrl)}`;
 

--- a/src/angular2-token.service.ts
+++ b/src/angular2-token.service.ts
@@ -260,21 +260,26 @@ export class Angular2TokenService implements CanActivate {
         if (updatePasswordData.userType != null)
             this._currentUserType = this._getUserTypeByName(updatePasswordData.userType);
 
-        let body: string;
+        let args: any;
 
         if (updatePasswordData.passwordCurrent == null) {
-            body = JSON.stringify({
+            args = {
                 password:               updatePasswordData.password,
                 password_confirmation:  updatePasswordData.passwordConfirmation
-            });
+            }
         } else {
-            body = JSON.stringify({
+            args = {
                 current_password:       updatePasswordData.passwordCurrent,
                 password:               updatePasswordData.password,
                 password_confirmation:  updatePasswordData.passwordConfirmation
-            });
+            };
         }
 
+        if (updatePasswordData.resetPasswordToken) {
+            args.reset_password_token = updatePasswordData.resetPasswordToken;
+        }
+
+        let body = JSON.stringify(args);
         return this.put(this._constructUserPath() + this._options.updatePasswordPath, body);
     }
 

--- a/src/angular2-token.service.ts
+++ b/src/angular2-token.service.ts
@@ -154,6 +154,7 @@ export class Angular2TokenService implements CanActivate {
 
         let body = JSON.stringify({
             email:                  registerData.email,
+            name:                   registerData.name,
             password:               registerData.password,
             password_confirmation:  registerData.passwordConfirmation,
             confirm_success_url:    this._options.registerAccountCallback


### PR DESCRIPTION
I have an Angular2 app which uses a separate Rails/Devise backend. I needed the oAuth flow to hit that server rather than the host which serves my frontend client. This pull helps deal with that.

- Added new `oAuthBase` option for the oAuth flow
- Added new `apiBase` option for other API calls
- Added a [string:string] object `oAuthWindowOptions` to allow users to set additional options on the new window (ex. `oAuthWindowOptions: { width: '800', height: '600' }`)
- I switched to using backticks for strings which have variable interpolation. It didn't compile with just straight up single-quotes for me
- Updated docs

Thanks for taking the lead on an excellent package.