### PR TITLE
fix: ApiPath doesn't contain double slashes anymore and the getApiPat…

### DIFF
--- a/src/angular2-token.service.ts
+++ b/src/angular2-token.service.ts
@@ -312,14 +312,14 @@ export class Angular2TokenService implements CanActivate {
 
     get(url: string, options?: RequestOptionsArgs): Observable<Response> {
         return this.request(this.mergeRequestOptionsArgs({
-            url:    this.getApiPath() + url,
+            url:    this.getApiPath(url),
             method: RequestMethod.Get
         }, options));
     }
 
     post(url: string, body: any, options?: RequestOptionsArgs): Observable<Response> {
         return this.request(this.mergeRequestOptionsArgs({
-            url:    this.getApiPath() + url,
+            url:    this.getApiPath(url),
             method: RequestMethod.Post,
             body:   body
         }, options));
@@ -327,7 +327,7 @@ export class Angular2TokenService implements CanActivate {
 
     put(url: string, body: any, options?: RequestOptionsArgs): Observable<Response> {
         return this.request(this.mergeRequestOptionsArgs({
-            url:    this.getApiPath() + url,
+            url:    this.getApiPath(url),
             method: RequestMethod.Put,
             body:   body
         }, options));
@@ -335,14 +335,14 @@ export class Angular2TokenService implements CanActivate {
 
     delete(url: string, options?: RequestOptionsArgs): Observable<Response> {
         return this.request(this.mergeRequestOptionsArgs({
-            url:    this.getApiPath() + url,
+            url:    this.getApiPath(url),
             method: RequestMethod.Delete
         }, options));
     }
 
     patch(url: string, body: any, options?: RequestOptionsArgs): Observable<Response> {
         return this.request(this.mergeRequestOptionsArgs({
-            url:    this.getApiPath() + url,
+            url:    this.getApiPath(url),
             method: RequestMethod.Patch,
             body:   body
         }, options));
@@ -351,13 +351,13 @@ export class Angular2TokenService implements CanActivate {
     head(path: string, options?: RequestOptionsArgs): Observable<Response> {
         return this.request({
             method: RequestMethod.Head,
-            url:    this.getApiPath() + path
+            url:    this.getApiPath(path)
         });
     }
 
     options(url: string, options?: RequestOptionsArgs): Observable<Response> {
         return this.request(this.mergeRequestOptionsArgs({
-            url:    this.getApiPath() + url,
+            url:    this.getApiPath(url),
             method: RequestMethod.Options
         }, options));
     }
@@ -557,14 +557,17 @@ export class Angular2TokenService implements CanActivate {
             return this.atCurrentUserType.path + '/';
     }
 
-    private getApiPath(): string {
+    private getApiPath(endPoint: string = ''): string {
         let constructedPath = '';
 
-        if (this.atOptions.apiBase != null)
+        if (this.atOptions.apiBase !== null)
             constructedPath += this.atOptions.apiBase + '/';
 
-        if (this.atOptions.apiPath != null)
+        if (this.atOptions.apiPath !== null)
             constructedPath += this.atOptions.apiPath + '/';
+
+        constructedPath += endPoint;
+        constructedPath = constructedPath.replace(/([^:]\/)\/+/g, "$1");
 
         return constructedPath;
     }


### PR DESCRIPTION
Basically, I made getApiPath responsible for building the entire url. This seems more neat than having a function return the basePath and appending the endpoint to it on the fly.

So, the getApiPath now takes parameters endpoint:string and appends that to the constructedPath. Afterwards, all double-slashes get replaced. We could discuss changing the name of getApiPath to constructApiPath or something, since that will better describe it's functionality.

I tried finding a better way to construct an URL out of baseparts, but this is the quickest solution.

Based on issue described in #184, since I was having this same issue as well.