### PR TITLE
update readme to match updatePassword interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,8 +266,7 @@ this._tokenService.validateToken().subscribe(
 
 ### .updatePassword()
 Updates the password for the logged in user.
-
-`updatePassword({password: string, passwordConfirmation: string, currentPassword?: string, userType?: string, resetPasswordToken?: string}): Observable<Response>`
+`updatePassword({password: string, passwordConfirmation: string, passwordCurrent: string, userType?: string, resetPasswordToken?: string}): Observable<Response>`
 
 #### Example:
 ```javascript


### PR DESCRIPTION
Fixes an error in the interface description in the README to match the **UpdatePasswordData** interface in angular2-token.model.ts