### PR TITLE
make passwordCurrent an optional param

### DIFF
--- a/src/angular2-token.model.ts
+++ b/src/angular2-token.model.ts
@@ -21,7 +21,7 @@ export interface RegisterData {
 export interface UpdatePasswordData {
     password:               string;
     passwordConfirmation:   string;
-    passwordCurrent:        string;
+    passwordCurrent?:       string;
     userType?:              string;
     resetPasswordToken?:    string;
 }


### PR DESCRIPTION
This makes the passwordCurrent attribute optional in the interface. Check out the problems when trying to reset a password when the user is not already authenticated or has forgotten their password. Setting this property to null before sending it fixes the problem, so just having a model that doesn't require it should prevent the workaround.

https://github.com/neroniaky/angular2-token/issues/205#issuecomment-304314425

Here the property is already been checked against "null", meaning if it's a required string this line of code will never be reached: https://github.com/neroniaky/angular2-token/blob/master/src/angular2-token.service.ts#L270