### PR TITLE
Custom Login Field

### DIFF
--- a/src/angular2-token.model.ts
+++ b/src/angular2-token.model.ts
@@ -1,7 +1,7 @@
 // Function Data
 
 export interface SignInData {
-    email:                  string;
+    login:                  string;
     password:               string;
     userType?:              string;
 }
@@ -84,6 +84,7 @@ export interface Angular2TokenOptions {
     resetPasswordCallback?:     string;
 
     userTypes?:                 UserType[];
+    loginField?:                string;
 
     oAuthBase?:                 string;
     oAuthPaths?:                { [key:string]: string; };

--- a/src/angular2-token.service.ts
+++ b/src/angular2-token.service.ts
@@ -121,6 +121,7 @@ export class Angular2TokenService implements CanActivate {
             resetPasswordPath:          'auth/password',
             resetPasswordCallback:      window.location.href,
 
+            loginField:                 'email',
             userTypes:                  null,
 
             oAuthBase:                  window.location.origin,
@@ -182,7 +183,7 @@ export class Angular2TokenService implements CanActivate {
             this.atCurrentUserType = this.getUserTypeByName(signInData.userType);
 
         let body = JSON.stringify({
-            email:      signInData.email,
+            [this.atOptions.loginField]:  signInData.login,
             password:   signInData.password
         });
 
@@ -370,7 +371,7 @@ export class Angular2TokenService implements CanActivate {
 
         // Get auth data from local storage
         this.getAuthDataFromStorage();
-        
+
         // Merge auth headers to request if set
         if (this.atCurrentAuthData != null) {
             (<any>Object).assign(baseHeaders, {

--- a/src/angular2-token.spec.ts
+++ b/src/angular2-token.spec.ts
@@ -33,7 +33,7 @@ describe('Angular2TokenService', () => {
 	});
 
 	let signInData: SignInData = {
-		email: 'test@test.de',
+		login: 'test@test.de',
 		password: 'password'
 	}
 
@@ -87,7 +87,7 @@ describe('Angular2TokenService', () => {
 
 		mockBackend.connections.subscribe(
 			c => {
-				expect(c.request.getBody()).toEqual(JSON.stringify(signInData));
+				expect(c.request.getBody()).toEqual(JSON.stringify({"email":"test@test.de","password":"password"}));
 				expect(c.request.method).toEqual(RequestMethod.Post);
 				expect(c.request.url).toEqual('auth/sign_in');
 			}
@@ -138,7 +138,7 @@ describe('Angular2TokenService', () => {
 		);
 
 		tokenService.init({ apiPath: 'myapi', signInPath: 'myauth/mysignin' });
-		tokenService.signIn(signInData.email, signInData.password);
+		tokenService.signIn(signInData.login, signInData.password);
 	}));
 
 	it('signOut should send to configured path', inject([Angular2TokenService, MockBackend], (tokenService, mockBackend) => {
@@ -225,6 +225,20 @@ describe('Angular2TokenService', () => {
 		tokenService.resetPassword('emxaple@example.org');
 	}));
 
+	it('signIn method should use custom loginField', inject([Angular2TokenService, MockBackend], (tokenService, mockBackend) => {
+
+		mockBackend.connections.subscribe(
+			c => {
+				expect(c.request.getBody()).toEqual(JSON.stringify({"username":"test@test.de","password":"password"}));
+				expect(c.request.method).toEqual(RequestMethod.Post);
+				expect(c.request.url).toEqual('auth/sign_in');
+			}
+		);
+
+		tokenService.init({ loginField: 'username' });
+		tokenService.signIn(signInData);
+	}));
+
 	// Testing Token handling
 
 	it('signIn method should receive headers and set local storage', inject([Angular2TokenService, MockBackend], (tokenService, mockBackend) => {
@@ -239,7 +253,7 @@ describe('Angular2TokenService', () => {
 		);
 
 		tokenService.init();
-		tokenService.signIn(signInData.email, signInData.password);
+		tokenService.signIn(signInData.login, signInData.password);
 
 		expect(localStorage.getItem('accessToken')).toEqual(accessToken);
 		expect(localStorage.getItem('client')).toEqual(client);


### PR DESCRIPTION
Added the ability to setup a custom login field other than email.
Added loginField to default options with value 'email'.
Updated SignInData interface to accept login instead of email attribute.
Updated Angular2TokenService to use loginField option to send auth info to server.